### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/extract.js
+++ b/assets/js/extract.js
@@ -1,4 +1,5 @@
 import { Sortable } from 'sortablejs/modular/sortable.core.esm';
+import DOMPurify from 'dompurify';
 document.addEventListener("DOMContentLoaded", () => {
     if (document.getElementById('sortref')){
         let sortEl = Sortable.create(document.getElementById('sortref'),{
@@ -132,9 +133,10 @@ function changeValueOfReference() {
                     doiContent = linkDoiTag.textContent
                 }
                 if (referenceDoiWished.value !== ""){
-                    linkDoiTag.href = "https://doi.org/"+referenceDoiWished.value;
-                    linkDoiTag.text = referenceDoiWished.value;
-                    linkDoiTag.textContent = referenceDoiWished.value;
+                    const sanitizedValue = DOMPurify.sanitize(referenceDoiWished.value);
+                    linkDoiTag.href = "https://doi.org/"+sanitizedValue;
+                    linkDoiTag.text = sanitizedValue;
+                    linkDoiTag.textContent = sanitizedValue;
                     doiContent = linkDoiTag.textContent
                 } else if (referenceDoiWished.value === "" && linkDoiTag !== null) {
                     linkDoiTag.remove();

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.0",
-        "sortablejs": "^1.15.0"
+        "sortablejs": "^1.15.0",
+        "dompurify": "^3.2.1"
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/CCSDForge/episciences-citations/security/code-scanning/1](https://github.com/CCSDForge/episciences-citations/security/code-scanning/1)

To fix the problem, we need to ensure that the `referenceDoiWished.value` is properly sanitized before being used in the URL. This can be done by using a library that provides escaping functions to ensure that any potentially malicious characters are neutralized.

The best way to fix this without changing existing functionality is to use a well-known library like `DOMPurify` to sanitize the input. We will import `DOMPurify` and use it to sanitize the `referenceDoiWished.value` before concatenating it into the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
