### PR TITLE
fix: remove JSON double-encoding and unnecessary array wrapping in PaperReferences

### DIFF
--- a/src/Command/GetBibRefCommand.php
+++ b/src/Command/GetBibRefCommand.php
@@ -251,7 +251,7 @@ class GetBibRefCommand extends Command
         }
         $reference = $refRetrieved;
         $ref = new PaperReferences();
-        $ref->setReference([json_encode($reference)]);
+        $ref->setReference($reference);
         $ref->setSource($source);
         $ref->setUpdatedAt(new \DateTimeImmutable());
         $ref->setReferenceOrder($counterRef++);
@@ -347,8 +347,7 @@ class GetBibRefCommand extends Command
                 $reOrdonateCounter = 0;
                 foreach ($docExisting->getPaperReferences() as $doc) {
                     $doc->setReferenceOrder($reOrdonateCounter);
-                    $referenceAlreadyAccepted[] =
-                        json_decode((string) $doc->getReference()[0], true, 512, JSON_THROW_ON_ERROR);
+                    $referenceAlreadyAccepted[] = $doc->getReference();
                     $this->entityManager->persist($doc);
                     $reOrdonateCounter++;
                     $counterRef++;

--- a/src/Command/MigrateReferenceFormatCommand.php
+++ b/src/Command/MigrateReferenceFormatCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\PaperReferences;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:migrate-references-format',
+    description: 'Migrate PaperReferences from double-encoded JSON to flat arrays',
+)]
+class MigrateReferenceFormatCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $refs = $this->entityManager->getRepository(PaperReferences::class)->findAll();
+        $migrated = 0;
+
+        foreach ($refs as $ref) {
+            $data = $ref->getReference();
+
+            // Detect old format: sequential array with exactly one string element (a JSON-encoded object)
+            if (!empty($data) && array_keys($data) === [0] && is_string($data[0])) {
+                try {
+                    $decoded = json_decode($data[0], true, 512, JSON_THROW_ON_ERROR);
+                    if (is_array($decoded) && !empty($decoded)) {
+                        $ref->setReference($decoded);
+                        $this->entityManager->persist($ref);
+                        $migrated++;
+                    }
+                } catch (\JsonException $e) {
+                    $output->writeln(sprintf(
+                        '<comment>Skipping reference #%d: %s</comment>',
+                        $ref->getId() ?? 0,
+                        $e->getMessage()
+                    ));
+                }
+            }
+        }
+
+        if ($migrated > 0) {
+            $this->entityManager->flush();
+        }
+
+        $output->writeln(sprintf('<info>Migrated %d reference(s).</info>', $migrated));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Form/DataTransformer/JsonTransformer.php
+++ b/src/Form/DataTransformer/JsonTransformer.php
@@ -21,7 +21,7 @@ class JsonTransformer implements DataTransformerInterface
             return [];
         }
 
-        return json_decode((string) $value);
+        return json_decode((string) $value, true, 512, JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/src/Services/Bibtex.php
+++ b/src/Services/Bibtex.php
@@ -144,59 +144,51 @@ class Bibtex
             return ['error' => $bibtex['error']];
         }
 
+        $user = $this->entityManager->getRepository(UserInformations::class)->find($userInfo['UID']);
+        if (is_null($user)) {
+            $user = new UserInformations();
+            $user->setId($userInfo['UID']);
+            $user->setSurname($userInfo['FIRSTNAME']);
+            $user->setName($userInfo['LASTNAME']);
+        }
+        $document = $this->entityManager->getRepository(Document::class)->find($docId);
         foreach ($bibtex as $bibtexInfo) {
             if (array_key_exists('crossref_doi', $bibtexInfo)) {
                 $csl = $this->doi->getCsl($bibtexInfo['crossref_doi']);
-                $reference = (['csl' => json_decode($csl, true, 512, JSON_THROW_ON_ERROR),
-                    'doi' => $bibtexInfo['crossref_doi']]);
+                $reference = ['csl' => json_decode($csl, true, 512, JSON_THROW_ON_ERROR),
+                    'doi' => $bibtexInfo['crossref_doi']];
             } else {
-                $csl = self::generateCSL($bibtexInfo);
-                $reference = (['csl' => $csl]);
+                $reference = ['csl' => self::generateCSL($bibtexInfo)];
             }
             $ref = new PaperReferences();
-            $ref->setReference([json_encode($reference)]);
+            $ref->setReference($reference);
             $ref->setSource(PaperReferences::SOURCE_METADATA_BIBTEX_IMPORT);
-            $user = $this->entityManager->getRepository(UserInformations::class)->find($userInfo['UID']);
-            if (is_null($user)) {
-                $user = new UserInformations();
-                $user->setId($userInfo['UID']);
-                $user->setSurname($userInfo['FIRSTNAME']);
-                $user->setName($userInfo['LASTNAME']);
-            }
             $ref->setUid($user);
             $ref->setAccepted(1);
             $ref->setUpdatedAt(new \DateTimeImmutable());
-            $ref->setDocument($this->entityManager->getRepository(Document::class)->find($docId));
+            $ref->setDocument($document);
             $ref->setReferenceOrder($countAllRef++);
             $this->entityManager->persist($ref);
-            $this->entityManager->flush();
         }
+        $this->entityManager->flush();
         return [];
     }
 
     /**
-     * @param $jsonCsl
-     * @return false|mixed|string
-     * @throws \JsonException
      * @throws CiteProcException
+     * @throws \JsonException
      */
-    public function getCslRefText($jsonCsl) {
-        $jsonReference = json_decode((string) $jsonCsl, true, 512, JSON_THROW_ON_ERROR);
-        // Check if 'csl' key is set in $jsonReference
-        if (array_key_exists('csl',$jsonReference)) {
-            // Extract CSL data and render bibliography
-            $jsonArray = [$jsonReference['csl']];
-            $jsonArray = json_encode($jsonArray, JSON_THROW_ON_ERROR);
+    public function getCslRefText(array $refData): array
+    {
+        if (array_key_exists('csl', $refData)) {
+            $jsonArray = json_encode([$refData['csl']], JSON_THROW_ON_ERROR);
             $style = StyleSheet::loadStyleSheet("apa");
             $citeProc = new CiteProc($style, "en-US");
-            $bibliography = $citeProc->render(json_decode($jsonArray), "bibliography");
-            // Process raw reference and assign to 'raw_reference' key
-            $jsonReference['raw_reference'] = trim(htmlspecialchars_decode(strip_tags($bibliography)));
-            $jsonReference['raw_reference'] = str_replace(self::REPLACE_CSL_EXCEPTION_STRING
-                ,'',$jsonReference['raw_reference']);
-            unset($jsonReference['csl']);
-            return json_encode($jsonReference);
+            $bibliography = $citeProc->render(json_decode($jsonArray, false, 512, JSON_THROW_ON_ERROR), "bibliography");
+            $refData['raw_reference'] = trim(htmlspecialchars_decode(strip_tags($bibliography)));
+            $refData['raw_reference'] = str_replace(self::REPLACE_CSL_EXCEPTION_STRING, '', $refData['raw_reference']);
+            unset($refData['csl']);
         }
-        return $jsonCsl;
+        return $refData;
     }
 }

--- a/src/Services/References.php
+++ b/src/Services/References.php
@@ -60,7 +60,6 @@ class References {
 
     /**
      * @throws CiteProcException
-     * @throws \JsonException
      */
     public function getReferences(int $docId,string $type = "all"|"accepted"): array
     {
@@ -76,23 +75,16 @@ class References {
         /** @var PaperReferences $reference */
         foreach ($references as $reference) {
             $refId = $reference->getId();
-            $referenceArray = $reference->getReference();
+            $refData = $reference->getReference();
 
-            if (empty($referenceArray)) {
+            if (empty($refData)) {
                 continue;
             }
 
-            $firstReference = $referenceArray[0];
+            $rawReferences[$refId]['ref'] = $this->bibtex->getCslRefText($refData);
 
-            // Decoder UNE SEULE FOIS (optimisation - gain 30-40%)
-            $jsonReference = json_decode((string) $firstReference, true, 512, JSON_THROW_ON_ERROR);
-
-            // Traiter via bibtex pour le texte formaté
-            $rawReferences[$refId]['ref'] = $this->bibtex->getCslRefText($firstReference);
-
-            // Ajouter CSL seulement si présent
-            if (array_key_exists('csl', $jsonReference)) {
-                $rawReferences[$refId]['csl'] = $firstReference;
+            if (array_key_exists('csl', $refData)) {
+                $rawReferences[$refId]['csl'] = $refData;
             }
 
             $rawReferences[$refId]['isAccepted'] = $reference->getAccepted();
@@ -110,9 +102,6 @@ class References {
         return $this->entityManager->getRepository(Document::class)->find($docId);
     }
 
-    /**
-     * @throws \JsonException
-     */
     public function addNewReference(array $form, array $userInfo): bool
     {
         if ($form['addReference'] !== ""){
@@ -125,7 +114,7 @@ class References {
                 }
                 $refInfo['doi'] = $form['addReferenceDoi'];
             }
-            $ref->setReference([json_encode($refInfo,JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+            $ref->setReference($refInfo);
             $ref->setSource(PaperReferences::SOURCE_METADATA_EPI_USER);
             $user = $this->entityManager->getRepository(UserInformations::class)->find($userInfo['UID']);
             if (is_null($user)) {

--- a/src/Services/Tei.php
+++ b/src/Services/Tei.php
@@ -17,11 +17,10 @@ class Tei
 
     /**
      * @param $tei
-     * @throws \JsonException
+     * @return array<int, array<string, string>>
      */
     public function getReferencesInTei($tei): array
     {
-
         $tei = simplexml_load_string((string) $tei);
         $info = [];
         if ($tei !== false) {
@@ -38,7 +37,7 @@ class Tei
                         (string)$value->analytic->idno->attributes() === 'DOI') {
                         $raw_reference['doi'] = (string)$value->analytic->idno;
                     }
-                    $info[] = json_encode($raw_reference, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+                    $info[] = $raw_reference;
                 }
             }
             return $info;
@@ -56,8 +55,7 @@ class Tei
             $reOrdonateCounter = 0;
             foreach ($docExisting->getPaperReferences() as $doc) {
                 $doc->setReferenceOrder($reOrdonateCounter);
-                $referenceAlreadyAcceptedByUser[] = serialize(
-                    json_decode((string) $doc->getReference()[0], true, 512, JSON_THROW_ON_ERROR));
+                $referenceAlreadyAcceptedByUser[] = serialize($doc->getReference());
                 $this->entityManager->persist($doc);
                 $reOrdonateCounter++;
                 $counterRef++;
@@ -69,10 +67,9 @@ class Tei
             $doc->setId($docId);
         }
         foreach ($references as $reference) {
-            if (!in_array(serialize(json_decode((string) $reference, true, 512, JSON_THROW_ON_ERROR)),
-                $referenceAlreadyAcceptedByUser, true)) {
+            if (!in_array(serialize($reference), $referenceAlreadyAcceptedByUser, true)) {
                 $refs = new PaperReferences();
-                $refs->setReference((array)($reference));
+                $refs->setReference($reference);
                 $refs->setSource($source);
                 $refs->setUpdatedAt(new \DateTimeImmutable());
                 $refs->setReferenceOrder($counterRef);

--- a/src/Twig/JsonGrobidExtension.php
+++ b/src/Twig/JsonGrobidExtension.php
@@ -95,42 +95,32 @@ class JsonGrobidExtension extends AbstractExtension
 
     public function prettyReference(string $jsonRawReference): array
     {
-        // Initialize an empty array to store the processed reference
         $jsonReference = [];
-
-        // Check if $jsonRawReference is not empty
         if ($jsonRawReference !== '' && $jsonRawReference !== '0') {
             try {
-                // Decode the JSON string to an associative array
-                $jsonRawReferenceArray = json_decode($jsonRawReference, true, 512, JSON_THROW_ON_ERROR);
+                $jsonReference = json_decode($jsonRawReference, true, 512, JSON_THROW_ON_ERROR);
+                if (!is_array($jsonReference)) {
+                    return [];
+                }
 
-                // Check if the first element of the array is set and decode it
-                if (isset($jsonRawReferenceArray[0])) {
-                    $jsonReference = json_decode((string) $jsonRawReferenceArray[0], true, 512, JSON_THROW_ON_ERROR);
-
-                    // Check if 'csl' key is set in $jsonReference
-                    if (isset($jsonReference['csl'])) {
-                        // Extract CSL data and render bibliography
-                        $jsonArray = [$jsonReference['csl']];
-                        $jsonArray = json_encode($jsonArray, JSON_THROW_ON_ERROR);
-                        $style = StyleSheet::loadStyleSheet("apa");
-                        $citeProc = new CiteProc($style, "en-US");
-                        $bibliography = $citeProc->render(json_decode
-                        ($jsonArray, false, 512, JSON_THROW_ON_ERROR));
-                        // Process raw reference and assign to 'raw_reference' key
-                        $jsonReference['raw_reference'] = trim(htmlspecialchars_decode(strip_tags($bibliography)));
-                        $jsonReference['raw_reference'] = str_replace(Bibtex::REPLACE_CSL_EXCEPTION_STRING
-                            ,'',$jsonReference['raw_reference']);
-                        unset($jsonReference['csl']);
-                        $jsonReference['forbiddenModify'] = 1;
-                    }
+                if (isset($jsonReference['csl'])) {
+                    $jsonArray = json_encode([$jsonReference['csl']], JSON_THROW_ON_ERROR);
+                    $style = StyleSheet::loadStyleSheet("apa");
+                    $citeProc = new CiteProc($style, "en-US");
+                    $bibliography = $citeProc->render(json_decode($jsonArray, false, 512, JSON_THROW_ON_ERROR));
+                    $jsonReference['raw_reference'] = trim(htmlspecialchars_decode(strip_tags($bibliography)));
+                    $jsonReference['raw_reference'] = str_replace(
+                        Bibtex::REPLACE_CSL_EXCEPTION_STRING,
+                        '',
+                        $jsonReference['raw_reference']
+                    );
+                    unset($jsonReference['csl']);
+                    $jsonReference['forbiddenModify'] = 1;
                 }
             } catch (JsonException|CiteProcException) {
-                // Handle JSON decoding errors or CiteProc exceptions
                 return [];
             }
         }
-
         return $jsonReference;
     }
 }

--- a/tests/Fixtures/PaperReferencesFixtures.php
+++ b/tests/Fixtures/PaperReferencesFixtures.php
@@ -24,7 +24,7 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 1 : Références acceptées (source GROBID)
         $ref1 = new PaperReferences();
-        $ref1->setReference([json_encode([
+        $ref1->setReference([
             'raw_reference' => 'John Doe et al. Test Article. Test Journal, 2024.',
             'doi' => '10.1234/test1',
             'csl' => [
@@ -32,9 +32,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
                 'title' => 'Test Article',
                 'author' => [['family' => 'Doe', 'given' => 'John']],
                 'issued' => ['date-parts' => [[2024]]],
-                'container-title' => 'Test Journal'
-            ]
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+                'container-title' => 'Test Journal',
+            ],
+        ]);
         $ref1->setSource(PaperReferences::SOURCE_METADATA_GROBID);
         $ref1->setAccepted(1);
         $ref1->setReferenceOrder(0);
@@ -45,10 +45,10 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 1 : Référence acceptée (source USER - modifiée par utilisateur)
         $ref2 = new PaperReferences();
-        $ref2->setReference([json_encode([
+        $ref2->setReference([
             'raw_reference' => 'Jane Smith. Modified Reference. Custom Journal, 2023.',
-            'doi' => '10.5678/test2'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+            'doi' => '10.5678/test2',
+        ]);
         $ref2->setSource(PaperReferences::SOURCE_METADATA_EPI_USER);
         $ref2->setAccepted(1);
         $ref2->setReferenceOrder(1);
@@ -59,9 +59,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 1 : Référence acceptée (source USER)
         $ref3 = new PaperReferences();
-        $ref3->setReference([json_encode([
-            'raw_reference' => 'Another Author. Another Article. Journal, 2022.'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+        $ref3->setReference([
+            'raw_reference' => 'Another Author. Another Article. Journal, 2022.',
+        ]);
         $ref3->setSource(PaperReferences::SOURCE_METADATA_EPI_USER);
         $ref3->setAccepted(1);
         $ref3->setReferenceOrder(2);
@@ -72,9 +72,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 1 : Référence NON acceptée (source GROBID)
         $ref4 = new PaperReferences();
-        $ref4->setReference([json_encode([
-            'raw_reference' => 'Unvalidated Reference 1. Unknown Journal, 2021.'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+        $ref4->setReference([
+            'raw_reference' => 'Unvalidated Reference 1. Unknown Journal, 2021.',
+        ]);
         $ref4->setSource(PaperReferences::SOURCE_METADATA_GROBID);
         $ref4->setAccepted(0);
         $ref4->setReferenceOrder(3);
@@ -84,9 +84,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 1 : Référence NON acceptée (source GROBID)
         $ref5 = new PaperReferences();
-        $ref5->setReference([json_encode([
-            'raw_reference' => 'Unvalidated Reference 2. Unknown Source, 2020.'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+        $ref5->setReference([
+            'raw_reference' => 'Unvalidated Reference 2. Unknown Source, 2020.',
+        ]);
         $ref5->setSource(PaperReferences::SOURCE_METADATA_GROBID);
         $ref5->setAccepted(0);
         $ref5->setReferenceOrder(4);
@@ -96,7 +96,7 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 2 : Références importées depuis BibTeX
         $ref6 = new PaperReferences();
-        $ref6->setReference([json_encode([
+        $ref6->setReference([
             'raw_reference' => 'BibTeX Import 1. From File Import, 2023.',
             'doi' => '10.9999/import1',
             'csl' => [
@@ -104,9 +104,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
                 'title' => 'Imported Book',
                 'author' => [['family' => 'Author', 'given' => 'Test']],
                 'issued' => ['date-parts' => [[2023]]],
-                'publisher' => 'Test Publisher'
-            ]
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+                'publisher' => 'Test Publisher',
+            ],
+        ]);
         $ref6->setSource(PaperReferences::SOURCE_METADATA_BIBTEX_IMPORT);
         $ref6->setAccepted(1);
         $ref6->setReferenceOrder(0);
@@ -117,9 +117,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 2 : Référence BibTeX import (non acceptée)
         $ref7 = new PaperReferences();
-        $ref7->setReference([json_encode([
-            'raw_reference' => 'BibTeX Import 2. Pending Review, 2022.'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+        $ref7->setReference([
+            'raw_reference' => 'BibTeX Import 2. Pending Review, 2022.',
+        ]);
         $ref7->setSource(PaperReferences::SOURCE_METADATA_BIBTEX_IMPORT);
         $ref7->setAccepted(0);
         $ref7->setReferenceOrder(1);
@@ -129,11 +129,11 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 2 : Référence Semantic Scholar
         $ref8 = new PaperReferences();
-        $ref8->setReference([json_encode([
+        $ref8->setReference([
             'raw_reference' => 'Semantic Scholar Reference. AI Journal, 2024.',
-            'doi' => '10.1111/s2test'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
-        $ref8->setSource(PaperReferences::SOURCE_METADATA_SEMANTICS);
+            'doi' => '10.1111/s2test',
+        ]);
+        $ref8->setSource(PaperReferences::SOURCE_SEMANTICS_SCHOLAR);
         $ref8->setAccepted(1);
         $ref8->setReferenceOrder(2);
         $ref8->setDocument($doc2);
@@ -143,9 +143,9 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 2 : Référence sans CSL
         $ref9 = new PaperReferences();
-        $ref9->setReference([json_encode([
-            'raw_reference' => 'Reference without CSL. Simple Text, 2023.'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+        $ref9->setReference([
+            'raw_reference' => 'Reference without CSL. Simple Text, 2023.',
+        ]);
         $ref9->setSource(PaperReferences::SOURCE_METADATA_GROBID);
         $ref9->setAccepted(1);
         $ref9->setReferenceOrder(3);
@@ -155,10 +155,10 @@ class PaperReferencesFixtures extends Fixture implements DependentFixtureInterfa
 
         // Document 2 : Référence avec DOI mais sans CSL
         $ref10 = new PaperReferences();
-        $ref10->setReference([json_encode([
+        $ref10->setReference([
             'raw_reference' => 'DOI only reference. Test, 2021.',
-            'doi' => '10.7777/doi-only'
-        ], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)]);
+            'doi' => '10.7777/doi-only',
+        ]);
         $ref10->setSource(PaperReferences::SOURCE_METADATA_GROBID);
         $ref10->setAccepted(0);
         $ref10->setReferenceOrder(4);

--- a/tests/Unit/Command/MigrateReferenceFormatCommandTest.php
+++ b/tests/Unit/Command/MigrateReferenceFormatCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\MigrateReferenceFormatCommand;
+use App\Entity\PaperReferences;
+use App\Repository\PaperReferencesRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class MigrateReferenceFormatCommandTest extends TestCase
+{
+    private MockObject $entityManager;
+    private MockObject $repository;
+    private MigrateReferenceFormatCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->repository = $this->createMock(PaperReferencesRepository::class);
+
+        $this->entityManager->method('getRepository')
+            ->with(PaperReferences::class)
+            ->willReturn($this->repository);
+
+        $this->command = new MigrateReferenceFormatCommand($this->entityManager);
+    }
+
+    #[Test]
+    public function testExecute_OldFormat_MigratesAndFlushes(): void
+    {
+        // Arrange — old format: single-element sequential array containing a JSON string
+        $ref = new PaperReferences();
+        $ref->setReference([json_encode(['raw_reference' => 'Author. Title. Journal, 2024.', 'doi' => '10.1/x'])]);
+
+        $this->repository->method('findAll')->willReturn([$ref]);
+        $this->entityManager->expects($this->once())->method('persist')->with($ref);
+        $this->entityManager->expects($this->once())->method('flush');
+
+        // Act
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        // Assert
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Migrated 1 reference(s)', $tester->getDisplay());
+
+        // Verify reference was converted to flat array
+        $migrated = $ref->getReference();
+        $this->assertArrayHasKey('raw_reference', $migrated);
+        $this->assertEquals('Author. Title. Journal, 2024.', $migrated['raw_reference']);
+        $this->assertArrayHasKey('doi', $migrated);
+        $this->assertEquals('10.1/x', $migrated['doi']);
+    }
+
+    #[Test]
+    public function testExecute_NewFormat_SkipsAndDoesNotFlush(): void
+    {
+        // Arrange — new format: associative array (already migrated)
+        $ref = new PaperReferences();
+        $ref->setReference(['raw_reference' => 'Author. Title. Journal, 2024.']);
+
+        $this->repository->method('findAll')->willReturn([$ref]);
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        // Act
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        // Assert
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Migrated 0 reference(s)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function testExecute_EmptyReference_Skipped(): void
+    {
+        // Arrange — empty reference (edge case)
+        $ref = new PaperReferences();
+        $ref->setReference([]);
+
+        $this->repository->method('findAll')->willReturn([$ref]);
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        // Act
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('Migrated 0 reference(s)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function testExecute_InvalidJsonInOldFormat_SkipsWithWarning(): void
+    {
+        // Arrange — old format with invalid JSON string inside the array
+        $ref = new PaperReferences();
+        $ref->setReference(['this is not valid json{{{']);
+
+        $this->repository->method('findAll')->willReturn([$ref]);
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        // Act
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Migrated 0 reference(s)', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function testExecute_MixedBatch_MigratesOnlyOldFormat(): void
+    {
+        // Arrange — mix of old and new format references
+        $oldRef = new PaperReferences();
+        $oldRef->setReference([json_encode(['raw_reference' => 'Old format ref'])]);
+
+        $newRef = new PaperReferences();
+        $newRef->setReference(['raw_reference' => 'New format ref', 'doi' => '10.1/y']);
+
+        $this->repository->method('findAll')->willReturn([$oldRef, $newRef]);
+        $this->entityManager->expects($this->once())->method('persist')->with($oldRef);
+        $this->entityManager->expects($this->once())->method('flush');
+
+        // Act
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('Migrated 1 reference(s)', $tester->getDisplay());
+
+        // Old ref was migrated to flat array
+        $this->assertArrayHasKey('raw_reference', $oldRef->getReference());
+        // New ref is unchanged
+        $this->assertEquals(['raw_reference' => 'New format ref', 'doi' => '10.1/y'], $newRef->getReference());
+    }
+
+    #[Test]
+    public function testExecute_NoReferences_ReportsZero(): void
+    {
+        $this->repository->method('findAll')->willReturn([]);
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('Migrated 0 reference(s)', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Entity/PaperReferencesTest.php
+++ b/tests/Unit/Entity/PaperReferencesTest.php
@@ -115,12 +115,10 @@ class PaperReferencesTest extends TestCase
     #[Test]
     public function testSetReference_ValidArray_SetsValue(): void
     {
-        // Arrange
+        // Arrange — flat associative array, Doctrine handles JSON serialization
         $reference = [
-            json_encode([
-                'raw_reference' => 'Smith, J. (2020). Test Article. Journal, 10(2), 123-145.',
-                'doi' => '10.1234/test'
-            ])
+            'raw_reference' => 'Smith, J. (2020). Test Article. Journal, 10(2), 123-145.',
+            'doi' => '10.1234/test',
         ];
 
         // Act

--- a/tests/Unit/Services/BibtexTest.php
+++ b/tests/Unit/Services/BibtexTest.php
@@ -143,34 +143,46 @@ class BibtexTest extends TestCase
     }
 
     #[Test]
-    public function testGetCslRefText_WithCSL(): void
+    public function testGetCslRefText_WithCSL_ReturnsArrayWithRenderedText(): void
     {
-        // Arrange
-        $jsonWithCsl = json_encode([
+        // Arrange — pass flat array, no JSON string
+        $refData = [
             'csl' => [
                 'type' => 'article-journal',
                 'title' => 'Test Article',
                 'author' => [
-                    ['family' => 'Doe', 'given' => 'John']
+                    ['family' => 'Doe', 'given' => 'John'],
                 ],
                 'issued' => ['date-parts' => [[2024]]],
-                'container-title' => 'Test Journal'
+                'container-title' => 'Test Journal',
             ],
-            'raw_reference' => 'Original raw text'
-        ]);
+            'raw_reference' => 'Original raw text',
+        ];
 
         // Act
-        $result = $this->service->getCslRefText($jsonWithCsl);
+        $result = $this->service->getCslRefText($refData);
 
-        // Assert
-        $this->assertIsString($result);
+        // Assert — result is an array, 'csl' key removed, 'raw_reference' updated
+        $this->assertIsArray($result);
+        $this->assertArrayNotHasKey('csl', $result, 'CSL key should be removed after rendering');
+        $this->assertArrayHasKey('raw_reference', $result);
+        $this->assertStringContainsString('Doe', $result['raw_reference']);
+    }
 
-        // Result should be formatted citation text (not JSON)
-        // CiteProc renders it, so we just verify it's not the original JSON
-        $this->assertStringNotContainsString('"csl"', $result);
+    #[Test]
+    public function testGetCslRefText_WithoutCSL_ReturnsUnchangedArray(): void
+    {
+        // Arrange — reference without CSL (e.g. from GROBID)
+        $refData = [
+            'raw_reference' => 'Author et al. Title. Journal, 2024.',
+            'doi' => '10.1234/test',
+        ];
 
-        // Verify the formatted text contains author name
-        // (CiteProc will format it as "Doe, J." or similar)
-        $this->assertStringContainsString('Doe', $result);
+        // Act
+        $result = $this->service->getCslRefText($refData);
+
+        // Assert — array returned as-is
+        $this->assertIsArray($result);
+        $this->assertEquals($refData, $result);
     }
 }

--- a/tests/Unit/Services/ReferencesTest.php
+++ b/tests/Unit/Services/ReferencesTest.php
@@ -152,23 +152,25 @@ class ReferencesTest extends TestCase
     #[Test]
     public function testGetReferences_AllType_ReturnsFormatted(): void
     {
-        // Arrange
+        // Arrange — flat arrays, no JSON string wrapping
         $docId = 123456;
 
         $ref1 = new PaperReferences();
         $ref1->setId(1);
-        $ref1->setReference([json_encode([
+        $ref1->setReference([
             'raw_reference' => 'Test ref 1',
-            'csl' => ['type' => 'article', 'title' => 'Test']
-        ])]);
+            'csl' => ['type' => 'article', 'title' => 'Test'],
+        ]);
         $ref1->setAccepted(1);
         $ref1->setReferenceOrder(0);
 
         $ref2 = new PaperReferences();
         $ref2->setId(2);
-        $ref2->setReference([json_encode(['raw_reference' => 'Test ref 2'])]);
+        $ref2->setReference(['raw_reference' => 'Test ref 2']);
         $ref2->setAccepted(0);
         $ref2->setReferenceOrder(1);
+
+        $formattedRef = ['raw_reference' => 'Formatted reference text'];
 
         // Mock Grobid service
         $this->grobid->expects($this->once())
@@ -176,10 +178,10 @@ class ReferencesTest extends TestCase
             ->with($docId)
             ->willReturn([$ref1, $ref2]);
 
-        // Mock Bibtex formatting
+        // getCslRefText now takes an array and returns an array
         $this->bibtex->expects($this->exactly(2))
             ->method('getCslRefText')
-            ->willReturn('Formatted reference text');
+            ->willReturn($formattedRef);
 
         // Act
         $result = $this->service->getReferences($docId, 'all');
@@ -189,11 +191,11 @@ class ReferencesTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertArrayHasKey(1, $result);
         $this->assertArrayHasKey(2, $result);
-        $this->assertEquals('Formatted reference text', $result[1]['ref']);
+        $this->assertEquals($formattedRef, $result[1]['ref']);
         $this->assertEquals(1, $result[1]['isAccepted']);
         $this->assertEquals(0, $result[1]['referenceOrder']);
-        $this->assertArrayHasKey('csl', $result[1]); // CSL present
-        $this->assertArrayNotHasKey('csl', $result[2]); // No CSL
+        $this->assertArrayHasKey('csl', $result[1]);    // CSL present in ref1
+        $this->assertArrayNotHasKey('csl', $result[2]); // No CSL in ref2
     }
 
     #[Test]

--- a/tests/Unit/Services/TeiTest.php
+++ b/tests/Unit/Services/TeiTest.php
@@ -42,8 +42,9 @@ class TeiTest extends TestCase
         $this->assertIsArray($result);
         $this->assertGreaterThan(0, count($result), 'Should extract at least one reference');
 
-        // Verify structure of the first reference
-        $firstRef = json_decode((string) $result[0], true);
+        // Each element is now a flat associative array (not a JSON string)
+        $firstRef = $result[0];
+        $this->assertIsArray($firstRef);
         $this->assertArrayHasKey('raw_reference', $firstRef);
         $this->assertNotEmpty($firstRef['raw_reference']);
     }
@@ -65,11 +66,11 @@ class TeiTest extends TestCase
     #[Test]
     public function testInsertReferencesInDB_NewDocument_CreatesDocumentAndReferences(): void
     {
-        // Arrange
+        // Arrange — references are now flat arrays, not JSON strings
         $docId = 123456;
         $references = [
-            json_encode(['raw_reference' => 'Test reference 1', 'doi' => '10.1234/test1']),
-            json_encode(['raw_reference' => 'Test reference 2'])
+            ['raw_reference' => 'Test reference 1', 'doi' => '10.1234/test1'],
+            ['raw_reference' => 'Test reference 2'],
         ];
         $source = PaperReferences::SOURCE_METADATA_GROBID;
 
@@ -106,10 +107,10 @@ class TeiTest extends TestCase
     #[Test]
     public function testInsertReferencesInDB_ExistingDocument_PreservesAcceptedReferences(): void
     {
-        // Arrange
+        // Arrange — references are now flat arrays
         $docId = 123456;
         $newReferences = [
-            json_encode(['raw_reference' => 'New reference 1'])
+            ['raw_reference' => 'New reference 1'],
         ];
         $source = PaperReferences::SOURCE_METADATA_GROBID;
 
@@ -119,7 +120,7 @@ class TeiTest extends TestCase
 
         $acceptedRef = new PaperReferences();
         $acceptedRef->setId(1);
-        $acceptedRef->setReference([json_encode(['raw_reference' => 'Accepted reference'])]);
+        $acceptedRef->setReference(['raw_reference' => 'Accepted reference']);
         $acceptedRef->setAccepted(1);
         $acceptedRef->setReferenceOrder(0);
         $acceptedRef->setDocument($existingDoc);

--- a/tests/Unit/Twig/JsonGrobidExtensionTest.php
+++ b/tests/Unit/Twig/JsonGrobidExtensionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Tests\Unit\Twig;
+
+use App\Twig\JsonGrobidExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class JsonGrobidExtensionTest extends TestCase
+{
+    private JsonGrobidExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new JsonGrobidExtension();
+    }
+
+    #[Test]
+    public function testPrettyReference_FlatReferenceWithoutCsl_ReturnsDecodedArray(): void
+    {
+        // Arrange — JSON string of a flat array (output of JsonTransformer::transform)
+        $refData = ['raw_reference' => 'Author et al. Title. Journal, 2024.', 'doi' => '10.1/x'];
+        $jsonInput = json_encode($refData);
+
+        // Act
+        $result = $this->extension->prettyReference($jsonInput);
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('raw_reference', $result);
+        $this->assertEquals('Author et al. Title. Journal, 2024.', $result['raw_reference']);
+        $this->assertArrayHasKey('doi', $result);
+        $this->assertArrayNotHasKey('csl', $result);
+        $this->assertArrayNotHasKey('forbiddenModify', $result);
+    }
+
+    #[Test]
+    public function testPrettyReference_ReferenceWithCsl_RendersAndSetsForbiddenModify(): void
+    {
+        // Arrange — reference with CSL data
+        $refData = [
+            'raw_reference' => 'Original text',
+            'csl' => [
+                'type' => 'article-journal',
+                'title' => 'Test Article',
+                'author' => [['family' => 'Doe', 'given' => 'John']],
+                'issued' => ['date-parts' => [[2024]]],
+                'container-title' => 'Test Journal',
+            ],
+        ];
+        $jsonInput = json_encode($refData);
+
+        // Act
+        $result = $this->extension->prettyReference($jsonInput);
+
+        // Assert
+        $this->assertIsArray($result);
+        $this->assertArrayNotHasKey('csl', $result, 'CSL key should be removed after rendering');
+        $this->assertArrayHasKey('raw_reference', $result);
+        $this->assertStringContainsString('Doe', $result['raw_reference']);
+        $this->assertEquals(1, $result['forbiddenModify']);
+    }
+
+    #[Test]
+    public function testPrettyReference_EmptyString_ReturnsEmptyArray(): void
+    {
+        $result = $this->extension->prettyReference('');
+        $this->assertEquals([], $result);
+    }
+
+    #[Test]
+    public function testPrettyReference_InvalidJson_ReturnsEmptyArray(): void
+    {
+        $result = $this->extension->prettyReference('not valid json {{{');
+        $this->assertEquals([], $result);
+    }
+
+    #[Test]
+    public function testGetFunctions_ContainsExpectedFunctions(): void
+    {
+        $functions = $this->extension->getFunctions();
+        $names = array_map(fn($f) => $f->getName(), $functions);
+
+        $this->assertContains('getAuthors', $names);
+        $this->assertContains('getDateInJson', $names);
+        $this->assertContains('getJournalIdentifier', $names);
+        $this->assertContains('prettyReference', $names);
+    }
+}


### PR DESCRIPTION
## Summary

- **Double-encoding supprimé** : `setReference([json_encode($data)])` stockait `["{\\"raw_reference\\":\\"...\\"}"]` au lieu de `{"raw_reference":"..."}`. Doctrine gère la sérialisation JSON automatiquement ; tous les appels manuels à `json_encode`/`json_decode` autour du champ `reference` ont été supprimés dans `Tei`, `Bibtex`, `References`, `GetBibRefCommand` et `JsonGrobidExtension`.
- **`JSON_PRETTY_PRINT` en base supprimé** : 11 occurrences qui gonflaient inutilement le stockage.
- **Flush en boucle corrigé** : `Bibtex::processBibtex()` fait maintenant un seul `flush()` après l'import (au lieu d'un par entrée BibTeX).
- **Bug de constante** : `PaperReferencesFixtures` référençait `SOURCE_METADATA_SEMANTICS` (inexistant) → corrigé en `SOURCE_SEMANTICS_SCHOLAR`.

## ⚠️ Breaking change API

`GET /visualize-citations` : les champs `ref` et `csl` sont maintenant des **objets JSON** au lieu de chaînes JSON. Les consommateurs de l'API n'ont plus besoin de faire `JSON.parse()` sur ces champs.

## Migration production

À lancer **une fois** après déploiement pour convertir les lignes existantes :

```bash
php bin/console app:migrate-references-format
```

La commande est idempotente (sans effet si déjà appliquée).

## Test plan

- [ ] Tous les tests unitaires passent (`make test-php`) : 109 tests, 0 échec
- [ ] Lancer `app:migrate-references-format` sur un dump de prod, vérifier que le nombre de lignes migrées correspond au total de la table `paper_references`
- [ ] Relancer la commande → doit afficher `Migrated 0 reference(s).`
- [ ] Vérifier l'affichage des références dans l'interface web (extraction GROBID, import BibTeX, ajout manuel)
- [ ] Vérifier la réponse de `GET /visualize-citations?url=<url>` — `ref` et `csl` doivent être des objets, non des chaînes