### PR TITLE
fix(security): prevent SSRF on /extract and /api/extract

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -63,4 +63,5 @@ API_RIGHT_URL="https://api.example.org" # Api which give authorization users
 API_S2_KEY="yourapikeySemanticsscholar"
 FORCE_HTTPS=true    #this is for the redirection cas
 EPISCIENCES_FORCE_HTTP=false # Force HTTP instead of HTTPS for episciences.org domains (dev only)
-API_EXTRACT_TOKEN= # Bearer token for GET /api/extract (empty = no authentication required)
+API_EXTRACT_TOKEN=changeme # MUST be changed before production (empty = no authentication required)
+# EPISCIENCES_ALLOWED_HOSTS=episciences.org # Optional: comma-separated allowed hostnames (default: episciences.org)

--- a/assets/__tests__/extract.test.js
+++ b/assets/__tests__/extract.test.js
@@ -37,8 +37,8 @@ describe('extract.js', () => {
                             <input id="textDoiRef-1" value="10.1000/new">
                         </div>
                         <div id="editActionBtns-1" class="d-none">
-                            <button id="acceptModifyBtn-1">Confirm</button>
-                            <button id="cancelModifyBtn-1">Cancel</button>
+                            <button type="button" id="acceptModifyBtn-1">Confirm</button>
+                            <button type="button" id="cancelModifyBtn-1">Cancel</button>
                         </div>
                         <input id="reference-1" value='{}'>
                         <input id="accepted-1" value="0">

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     deposit_pdf: '%kernel.project_dir%/var/data'
     api_extract_token_default: ''
     api_extract_token: '%env(default:api_extract_token_default:API_EXTRACT_TOKEN)%'
+    episciences_allowed_hosts_default: ''
     solr_reference_enrichment_enabled_default: false
     solr_base_url_default: 'http://localhost:8983/solr'
     solr_collection_default: 'ref_pps'
@@ -60,6 +61,7 @@ services:
             $pdfFolder: '%kernel.project_dir%/var/data/'
             $apiRight: '%env(string:API_RIGHT_URL)%'
             $forceHttp: '%env(bool:EPISCIENCES_FORCE_HTTP)%'
+            $allowedHosts: '%env(default:episciences_allowed_hosts_default:EPISCIENCES_ALLOWED_HOSTS)%'
     App\Services\Semanticsscholar:
         arguments:
             $apiKeyS2: '%env(string:API_S2_KEY)%'

--- a/src/Controller/ExtractController.php
+++ b/src/Controller/ExtractController.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -56,7 +57,7 @@ class ExtractController extends AbstractController
      * @throws TransportExceptionInterface
      */
     #[Route('/extract', name: 'app_extract')]
-    #[IsGranted('ROLE_USER')]
+    #[IsGranted(new Expression('is_granted("ROLE_USER") or is_granted("ROLE_ANO")'))]
     public function extract(Request $request): RedirectResponse|Response
     {
         $rawUrl = (string) $request->query->get('url', '');

--- a/src/Controller/ExtractController.php
+++ b/src/Controller/ExtractController.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -57,7 +56,7 @@ class ExtractController extends AbstractController
      * @throws TransportExceptionInterface
      */
     #[Route('/extract', name: 'app_extract')]
-    #[IsGranted(new Expression('is_granted("ROLE_USER") or is_granted("ROLE_ANO")'))]
+    #[IsGranted('ROLE_USER')]
     public function extract(Request $request): RedirectResponse|Response
     {
         $rawUrl = (string) $request->query->get('url', '');

--- a/src/Controller/ExtractController.php
+++ b/src/Controller/ExtractController.php
@@ -56,12 +56,16 @@ class ExtractController extends AbstractController
      * @throws TransportExceptionInterface
      */
     #[Route('/extract', name: 'app_extract')]
+    #[IsGranted('ROLE_USER')]
     public function extract(Request $request): RedirectResponse|Response
     {
+        $rawUrl = (string) $request->query->get('url', '');
+        if (!$this->episciences->isAllowedUrl($rawUrl)) {
+            throw $this->createAccessDeniedException('URL hostname not allowed');
+        }
 
-
-        $docId = (int) $this->episciences->getDocIdFromUrl($request->query->get('url'));
-        $getPdf = $this->episciences->getPaperPDF($request->query->get('url'));
+        $docId = (int) $this->episciences->getDocIdFromUrl($rawUrl);
+        $getPdf = $this->episciences->getPaperPDF($rawUrl);
 
         $this->logger->info('Extracting for docid ', ['DocId' => $docId]);
         $this->logger->info('Extracting for pdf ', ['PDF' => $getPdf]);
@@ -343,6 +347,13 @@ class ExtractController extends AbstractController
             return new JsonResponse(['success' => false, 'error' => 'Missing required parameter: url'], Response::HTTP_BAD_REQUEST);
         }
 
+        if (!$this->episciences->isAllowedUrl($url)) {
+            return new JsonResponse(
+                ['success' => false, 'error' => 'URL hostname not allowed'],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
         $docIdParam = $request->query->get('docid');
         $docId = $docIdParam !== null
             ? (int) $docIdParam
@@ -380,8 +391,15 @@ class ExtractController extends AbstractController
     private function isValidApiToken(Request $request): bool
     {
         $expected = (string) $this->getParameter('api_extract_token');
-        if ($expected === '') {
-            return true;
+        if ($expected === '' || $expected === 'changeme') {
+            if ($this->getParameter('kernel.environment') === 'prod') {
+                $this->logger->critical(
+                    'API_EXTRACT_TOKEN is not configured — /api/extract is unprotected in production'
+                );
+            }
+            if ($expected === '') {
+                return true;
+            }
         }
         return $request->headers->get('Authorization') === 'Bearer ' . $expected;
     }

--- a/src/Services/Episciences.php
+++ b/src/Services/Episciences.php
@@ -22,7 +22,11 @@ class Episciences {
 
     public function isAllowedUrl(string $url): bool
     {
-        $host = strtolower(parse_url($url, PHP_URL_HOST) ?? '');
+        $scheme = strtolower(parse_url($url, PHP_URL_SCHEME) ?? '');
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return false;
+        }
+        $host = strtolower(rawurldecode(parse_url($url, PHP_URL_HOST) ?? ''));
         if ($host === '') {
             return false;
         }

--- a/src/Services/Episciences.php
+++ b/src/Services/Episciences.php
@@ -9,12 +9,32 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class Episciences {
 
+    private const DEFAULT_ALLOWED_HOSTS = ['episciences.org'];
+
     public function __construct(private readonly HttpClientInterface $client,
                                 private readonly string $pdfFolder,
                                 private readonly string $apiRight,
                                 private readonly LoggerInterface $logger,
-                                private readonly bool $forceHttp = false)
+                                private readonly bool $forceHttp = false,
+                                private readonly string $allowedHosts = '')
     {
+    }
+
+    public function isAllowedUrl(string $url): bool
+    {
+        $host = strtolower(parse_url($url, PHP_URL_HOST) ?? '');
+        if ($host === '') {
+            return false;
+        }
+        $allowed = $this->allowedHosts !== ''
+            ? array_map('trim', explode(',', $this->allowedHosts))
+            : self::DEFAULT_ALLOWED_HOSTS;
+        foreach ($allowed as $pattern) {
+            if ($host === $pattern || str_ends_with($host, '.' . $pattern)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/tests/Functional/Controller/ExtractControllerTest.php
+++ b/tests/Functional/Controller/ExtractControllerTest.php
@@ -89,12 +89,54 @@ class ExtractControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $client->request(Request::METHOD_GET, '/api/extract?url=https://example.com/no-numeric-id', [], [], $this->authHeaders());
+        $client->request(Request::METHOD_GET, '/api/extract?url=https://lmcs.episciences.org/no-numeric-id', [], [], $this->authHeaders());
 
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $data = json_decode($client->getResponse()->getContent(), true);
         $this->assertFalse($data['success']);
         $this->assertStringContainsString('document ID', $data['error']);
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /api/extract — SSRF protection (URL allowlist)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function testApiExtract_SsrfBlocked_MetadataEndpoint(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            Request::METHOD_GET,
+            '/api/extract?url=http://169.254.169.254/latest/meta-data&docid=42',
+            [],
+            [],
+            $this->authHeaders()
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertFalse($data['success']);
+        $this->assertStringContainsString('not allowed', $data['error']);
+    }
+
+    #[Test]
+    public function testApiExtract_SsrfBlocked_ArbitraryHost(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            Request::METHOD_GET,
+            '/api/extract?url=http://internal-db:3306/123&docid=1',
+            [],
+            [],
+            $this->authHeaders()
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+        $data = json_decode($client->getResponse()->getContent(), true);
+        $this->assertFalse($data['success']);
+        $this->assertStringContainsString('not allowed', $data['error']);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Unit/Services/EpisciencesTest.php
+++ b/tests/Unit/Services/EpisciencesTest.php
@@ -424,4 +424,68 @@ class EpisciencesTest extends TestCase
         $this->assertFileExists($this->pdfFolder . $name . '.pdf');
         $this->assertEquals($pdfContent, file_get_contents($this->pdfFolder . $name . '.pdf'));
     }
+
+    // -------------------------------------------------------------------------
+    // isAllowedUrl — SSRF allowlist
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_EpisciencesSubdomain_ReturnsTrue(): void
+    {
+        $this->assertTrue($this->service->isAllowedUrl('https://lmcs.episciences.org/18068'));
+        $this->assertTrue($this->service->isAllowedUrl('https://transformations.episciences.org/articles/14776'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_EpisciencesRootDomain_ReturnsTrue(): void
+    {
+        $this->assertTrue($this->service->isAllowedUrl('https://episciences.org/article/view/12345'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_MetadataEndpoint_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->service->isAllowedUrl('http://169.254.169.254/latest/meta-data'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_InternalHost_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->service->isAllowedUrl('http://internal-db:3306/123'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_EmptyString_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->service->isAllowedUrl(''));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_SpoofedHostname_ReturnsFalse(): void
+    {
+        // e.g. evil.episciences.org.attacker.com should NOT match episciences.org
+        $this->assertFalse($this->service->isAllowedUrl('http://evil.episciences.org.attacker.com/123'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_CustomAllowedHosts_Override(): void
+    {
+        $custom = new Episciences(
+            $this->httpClient,
+            $this->pdfFolder,
+            $this->apiRight,
+            $this->logger,
+            false,
+            'example.org'
+        );
+        $this->assertTrue($custom->isAllowedUrl('https://sub.example.org/123'));
+        $this->assertFalse($custom->isAllowedUrl('https://lmcs.episciences.org/123'));
+    }
 }

--- a/tests/Unit/Services/EpisciencesTest.php
+++ b/tests/Unit/Services/EpisciencesTest.php
@@ -475,6 +475,22 @@ class EpisciencesTest extends TestCase
 
     #[Test]
     #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_PercentEncodedIp_ReturnsFalse(): void
+    {
+        // 169%2E254%2E169%2E254 decodes to 169.254.169.254 — must be blocked
+        $this->assertFalse($this->service->isAllowedUrl('http://169%2E254%2E169%2E254/latest/meta-data'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testIsAllowedUrl_NonHttpScheme_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->service->isAllowedUrl('ftp://lmcs.episciences.org/123'));
+        $this->assertFalse($this->service->isAllowedUrl('file:///etc/passwd'));
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function testIsAllowedUrl_CustomAllowedHosts_Override(): void
     {
         $custom = new Episciences(


### PR DESCRIPTION
## Summary

- **Vuln 1 (High)** — `GET /extract` was reachable without authentication and made unconstrained outbound HTTP requests with the caller-supplied URL, enabling internal network probing before any auth check.
- **Vuln 2 (High)** — `GET /api/extract` ships with `API_EXTRACT_TOKEN=` (empty) in `.env.dist`, disabling authentication entirely by default; the `url` parameter was passed unconstrained to the HTTP client.

Both vulnerabilities stemmed from the same root cause: no hostname validation on outbound requests.

## Changes

| File | Change |
|------|--------|
| `src/Services/Episciences.php` | Add `isAllowedUrl()` with a default allowlist of `episciences.org`; overridable via `EPISCIENCES_ALLOWED_HOSTS` |
| `src/Controller/ExtractController.php` | Add `#[IsGranted('ROLE_USER')]` to `extract()`; validate URL before outbound call in both routes; log `CRITICAL` in production when token is unset |
| `config/services.yaml` | Wire `EPISCIENCES_ALLOWED_HOSTS` env var into the Episciences service |
| `.env.dist` | Change `API_EXTRACT_TOKEN=` to `API_EXTRACT_TOKEN=changeme` to force operators to set a real value |

## Test plan

- [x] New unit tests: `isAllowedUrl()` — allowed subdomains, blocked internal IPs, blocked arbitrary hosts, spoofed hostname bypass attempt, custom override via `allowedHosts`
- [x] New functional tests: `/api/extract` with `169.254.169.254` and `internal-db:3306` returns HTTP 400
- [x] Existing test `testApiExtract_InvalidUrl` updated to use an `episciences.org` URL (now that non-allowlist URLs are rejected before docId resolution)
- [x] Full test suite: 131/131 pass
- [x] PHPStan level 6: no errors on modified files

**Manual smoke tests (against a running instance):**
1. `GET /extract?url=https://lmcs.episciences.org/123` without CAS session → redirect to CAS login
2. `GET /api/extract?url=http://169.254.169.254/latest/meta-data&docid=42` → `{"success":false,"error":"URL hostname not allowed"}` HTTP 400
3. `GET /api/extract?url=https://lmcs.episciences.org/123` with valid Bearer token → normal extraction flow
4. In production with `API_EXTRACT_TOKEN=changeme` → CRITICAL log entry appears