### PR TITLE
Fix: skip open-access links that duplicate the reference's own DOI

### DIFF
--- a/src/Command/PurgeRedundantOpenAccessLinksCommand.php
+++ b/src/Command/PurgeRedundantOpenAccessLinksCommand.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Entity\PaperReferences;
+use App\Services\OpenAccess\OpenAccessReferenceEnricher;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Removes 'open-access' data that was auto-resolved (origin: 'openalex') but only duplicates
+ * the reference's own DOI link (see OpenAccessReferenceEnricher::isRedundantWithDoiLink()).
+ *
+ * Historical data cleanup for references enriched before that redundancy check existed.
+ * User-provided open-access links (origin: 'user') are never touched.
+ */
+#[AsCommand(name: 'app:openaccess:purge-redundant-links', description: 'Remove auto-resolved open-access links that duplicate the reference\'s own DOI link')]
+class PurgeRedundantOpenAccessLinksCommand extends Command
+{
+    use ReferenceIdFilterTrait;
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly OpenAccessReferenceEnricher $openAccessReferenceEnricher,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('docid', null, InputOption::VALUE_REQUIRED, 'Limit processing to one document id')
+            ->addOption('source', null, InputOption::VALUE_REQUIRED, 'Limit processing to one source: GROBID, USER, BIBTEX, SEMANTICS')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show changes without writing to the database')
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Number of references per batch');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $source = $input->getOption('source');
+        if (is_string($source) && !$this->isValidSource($source)) {
+            $output->writeln('<error>Invalid source. Expected one of: GROBID, USER, BIBTEX, SEMANTICS.</error>');
+            return Command::INVALID;
+        }
+
+        $batchSize = is_numeric($input->getOption('batch-size')) ? max(1, (int) $input->getOption('batch-size')) : 50;
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $referenceIds = $this->getReferenceIds($input);
+        $stats = ['scanned' => 0, 'purged' => 0];
+
+        foreach (array_chunk($referenceIds, $batchSize) as $idBatch) {
+            $this->processBatch($idBatch, $dryRun, $output, $stats);
+        }
+
+        $output->writeln(sprintf(
+            'Open-access redundant link purge: scanned=%d purged=%d batchSize=%d dryRun=%s',
+            $stats['scanned'],
+            $stats['purged'],
+            $batchSize,
+            $dryRun ? 'yes' : 'no'
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<int, int> $idBatch
+     * @param array<string, int> $stats
+     */
+    private function processBatch(array $idBatch, bool $dryRun, OutputInterface $output, array &$stats): void
+    {
+        $paperReferences = $this->entityManager->getRepository(PaperReferences::class)->findBy(['id' => $idBatch]);
+        $changed = false;
+
+        foreach ($paperReferences as $paperReference) {
+            $stats['scanned']++;
+            $reference = $paperReference->getReference();
+
+            if (!$this->isPurgeableOpenAccessLink($reference)) {
+                continue;
+            }
+
+            $stats['purged']++;
+            if ($output->isVerbose()) {
+                $output->writeln(sprintf(
+                    'Purging redundant open-access link for DOI %s (reference id %d)',
+                    $reference['doi'],
+                    $paperReference->getId()
+                ));
+            }
+
+            if (!$dryRun) {
+                unset($reference['open-access']);
+                $paperReference->setReference($reference);
+                $paperReference->setUpdatedAt(new DateTimeImmutable());
+                $this->entityManager->persist($paperReference);
+                $changed = true;
+            }
+        }
+
+        if ($changed) {
+            $this->entityManager->flush();
+            $this->entityManager->clear();
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $reference
+     */
+    private function isPurgeableOpenAccessLink(array $reference): bool
+    {
+        if (!$this->hasDoi($reference)) {
+            return false;
+        }
+
+        $openAccess = $reference['open-access'] ?? null;
+        if (!is_array($openAccess) || ($openAccess['origin'] ?? null) !== 'openalex') {
+            return false;
+        }
+
+        return $this->openAccessReferenceEnricher->isRedundantWithDoiLink($reference['doi'], $openAccess['url'] ?? null);
+    }
+}

--- a/src/Services/OpenAccess/OpenAccessReferenceEnricher.php
+++ b/src/Services/OpenAccess/OpenAccessReferenceEnricher.php
@@ -63,11 +63,37 @@ class OpenAccessReferenceEnricher
         foreach ($doiByIndex as $index => $doi) {
             $result = $resultByDoi[$doi] ?? null;
             if ($result !== null) {
-                $references[$index] = $this->applyResult($references[$index], $result);
+                $references[$index] = $this->applyResult($references[$index], $doi, $result);
             }
         }
 
         return $references;
+    }
+
+    /**
+     * True when $url just points back to the DOI's own resolver link (e.g. a publisher landing
+     * page that already equals https://doi.org/{doi}), so storing it as "open access" would only
+     * duplicate the DOI link already shown for the reference.
+     */
+    public function isRedundantWithDoiLink(mixed $doi, mixed $url): bool
+    {
+        $normalizedDoi = $this->normalizeDoi($doi);
+        $sanitizedUrl = OpenAccessUrlSanitizer::sanitize($url);
+
+        if ($normalizedDoi === null || $sanitizedUrl === null) {
+            return false;
+        }
+
+        return $this->normalizeUrlForComparison($sanitizedUrl) === 'doi.org/' . $normalizedDoi;
+    }
+
+    private function normalizeUrlForComparison(string $url): string
+    {
+        $url = strtolower(rawurldecode($url));
+        $url = preg_replace('#^https?://#', '', $url) ?? $url;
+        $url = preg_replace('#^(?:www\.|dx\.)?doi\.org/#', 'doi.org/', $url) ?? $url;
+
+        return rtrim($url, '/');
     }
 
     /**
@@ -114,10 +140,10 @@ class OpenAccessReferenceEnricher
      * @param array<string, mixed> $reference
      * @return array<string, mixed>
      */
-    private function applyResult(array $reference, OpenAccessResult $result): array
+    private function applyResult(array $reference, string $doi, OpenAccessResult $result): array
     {
         $sanitizedUrl = OpenAccessUrlSanitizer::sanitize($result->url);
-        if ($sanitizedUrl === null) {
+        if ($sanitizedUrl === null || $this->isRedundantWithDoiLink($doi, $sanitizedUrl)) {
             return $reference;
         }
 

--- a/tests/Unit/Command/PurgeRedundantOpenAccessLinksCommandTest.php
+++ b/tests/Unit/Command/PurgeRedundantOpenAccessLinksCommandTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Command;
+
+use App\Command\PurgeRedundantOpenAccessLinksCommand;
+use App\Entity\PaperReferences;
+use App\Repository\PaperReferencesRepository;
+use App\Services\OpenAccess\OpenAccessReferenceEnricher;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PurgeRedundantOpenAccessLinksCommandTest extends TestCase
+{
+    private MockObject $entityManager;
+    private MockObject $repository;
+    private MockObject $openAccessReferenceEnricher;
+    private PurgeRedundantOpenAccessLinksCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->repository = $this->createMock(PaperReferencesRepository::class);
+        $this->openAccessReferenceEnricher = $this->createMock(OpenAccessReferenceEnricher::class);
+
+        $this->command = new PurgeRedundantOpenAccessLinksCommand($this->entityManager, $this->openAccessReferenceEnricher);
+    }
+
+    /**
+     * @param array<int, int> $ids
+     */
+    private function stubReferenceIds(array $ids): void
+    {
+        $query = $this->createStub(Query::class);
+        $query->method('getArrayResult')->willReturn(array_map(static fn (int $id): array => ['id' => $id], $ids));
+
+        $qb = $this->createStub(QueryBuilder::class);
+        $qb->method('select')->willReturn($qb);
+        $qb->method('from')->willReturn($qb);
+        $qb->method('orderBy')->willReturn($qb);
+        $qb->method('andWhere')->willReturn($qb);
+        $qb->method('setParameter')->willReturn($qb);
+        $qb->method('getQuery')->willReturn($query);
+
+        $this->entityManager->method('createQueryBuilder')->willReturn($qb);
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testInvalidSourceReturnsInvalidStatus(): void
+    {
+        $tester = new CommandTester($this->command);
+        $tester->execute(['--source' => 'NOT_A_SOURCE']);
+
+        $this->assertSame(Command::INVALID, $tester->getStatusCode());
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testPurgesRedundantOpenAlexLinkAndPersists(): void
+    {
+        $ref = new PaperReferences();
+        $ref->setReference([
+            'doi' => '10.1/a',
+            'open-access' => ['url' => 'https://doi.org/10.1/a', 'origin' => 'openalex'],
+        ]);
+
+        $this->stubReferenceIds([1]);
+        $this->entityManager->method('getRepository')->willReturn($this->repository);
+        $this->repository->method('findBy')->with(['id' => [1]])->willReturn([$ref]);
+
+        $this->openAccessReferenceEnricher->method('isRedundantWithDoiLink')
+            ->with('10.1/a', 'https://doi.org/10.1/a')
+            ->willReturn(true);
+
+        $this->entityManager->expects($this->once())->method('persist')->with($ref);
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('purged=1', $tester->getDisplay());
+        $this->assertArrayNotHasKey('open-access', $ref->getReference());
+        $this->assertNotNull($ref->getUpdatedAt());
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testDryRunDoesNotPersist(): void
+    {
+        $ref = new PaperReferences();
+        $ref->setReference([
+            'doi' => '10.1/a',
+            'open-access' => ['url' => 'https://doi.org/10.1/a', 'origin' => 'openalex'],
+        ]);
+
+        $this->stubReferenceIds([1]);
+        $this->entityManager->method('getRepository')->willReturn($this->repository);
+        $this->repository->method('findBy')->willReturn([$ref]);
+
+        $this->openAccessReferenceEnricher->method('isRedundantWithDoiLink')->willReturn(true);
+
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['--dry-run' => true]);
+
+        $this->assertStringContainsString('purged=1', $tester->getDisplay());
+        $this->assertArrayHasKey('open-access', $ref->getReference());
+        $this->assertNull($ref->getUpdatedAt());
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testSkipsManualOriginLinks(): void
+    {
+        $ref = new PaperReferences();
+        $ref->setReference([
+            'doi' => '10.1/a',
+            'open-access' => ['url' => 'https://doi.org/10.1/a', 'origin' => 'user'],
+        ]);
+
+        $this->stubReferenceIds([1]);
+        $this->entityManager->method('getRepository')->willReturn($this->repository);
+        $this->repository->method('findBy')->willReturn([$ref]);
+
+        $this->openAccessReferenceEnricher->expects($this->never())->method('isRedundantWithDoiLink');
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('purged=0', $tester->getDisplay());
+        $this->assertArrayHasKey('open-access', $ref->getReference());
+    }
+
+    #[Test]
+    #[AllowMockObjectsWithoutExpectations]
+    public function testNonRedundantOpenAlexLinkIsLeftUntouched(): void
+    {
+        $ref = new PaperReferences();
+        $ref->setReference([
+            'doi' => '10.1/a',
+            'open-access' => ['url' => 'https://oa.example/x', 'origin' => 'openalex'],
+        ]);
+
+        $this->stubReferenceIds([1]);
+        $this->entityManager->method('getRepository')->willReturn($this->repository);
+        $this->repository->method('findBy')->willReturn([$ref]);
+
+        $this->openAccessReferenceEnricher->method('isRedundantWithDoiLink')->willReturn(false);
+
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->never())->method('flush');
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString('purged=0', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Services/OpenAccess/OpenAccessReferenceEnricherTest.php
+++ b/tests/Unit/Services/OpenAccess/OpenAccessReferenceEnricherTest.php
@@ -78,6 +78,43 @@ class OpenAccessReferenceEnricherTest extends TestCase
         $this->assertArrayNotHasKey('open-access', $result);
     }
 
+    /**
+     * When the resolved open-access location is just the publisher's DOI landing page (i.e.
+     * the reference was already open access via its own DOI), storing it as "open-access"
+     * would only duplicate the DOI link already shown for the reference.
+     */
+    #[Test]
+    public function testResolutionEqualToDoiLinkDoesNotSetOpenAccessField(): void
+    {
+        $resolver = $this->createResolverReturning(['10.1234/test' => new OpenAccessResult('https://doi.org/10.1234/test', 'Publisher')]);
+
+        $reference = ['raw_reference' => 'Reference', 'doi' => '10.1234/test'];
+        $result = $this->createService($resolver)->enrichReference($reference);
+
+        $this->assertArrayNotHasKey('open-access', $result);
+    }
+
+    #[Test]
+    public function testResolutionEqualToDoiLinkViaDxDoiOrgDoesNotSetOpenAccessField(): void
+    {
+        $resolver = $this->createResolverReturning(['10.1234/test' => new OpenAccessResult('http://dx.doi.org/10.1234/TEST/', 'Publisher')]);
+
+        $reference = ['raw_reference' => 'Reference', 'doi' => '10.1234/test'];
+        $result = $this->createService($resolver)->enrichReference($reference);
+
+        $this->assertArrayNotHasKey('open-access', $result);
+    }
+
+    #[Test]
+    public function testIsRedundantWithDoiLinkComparesNormalizedForms(): void
+    {
+        $service = $this->createService($this->createStub(OpenAccessResolverInterface::class));
+
+        $this->assertTrue($service->isRedundantWithDoiLink('10.1234/Test', 'https://DOI.ORG/10.1234/test/'));
+        $this->assertFalse($service->isRedundantWithDoiLink('10.1234/test', 'https://oa.example/x'));
+        $this->assertFalse($service->isRedundantWithDoiLink(null, 'https://doi.org/10.1234/test'));
+    }
+
     #[Test]
     public function testFailedResolutionKeepsExistingOpenAccessData(): void
     {


### PR DESCRIPTION
## Summary
- OpenAlex sometimes resolves a `best_oa_location` that is just the DOI's own landing page (`https://doi.org/{doi}`), which `OpenAccessReferenceEnricher` was storing as a separate open-access link — duplicating the DOI link already shown for the reference.
- Added `OpenAccessReferenceEnricher::isRedundantWithDoiLink()` and skip applying the OpenAlex result when it just resolves back to the DOI link (normalizes scheme, `dx.`/`www.doi.org`, case, encoding, trailing slash).
- Added `app:openaccess:purge-redundant-links` console command to clean up existing references where this already happened. Only touches `origin: 'openalex'` links; user-provided open-access links (`origin: 'user'`) are never modified.

## Data audit (dev DB)
Of 2428 references with both a DOI and an OpenAlex-resolved open-access URL, **1433 (59%)** had an open-access URL identical to the reference's own `https://doi.org/{doi}` link — all with `origin: 'openalex'`. Confirmed via a dry-run of the new command: `scanned=10302 purged=1433`.

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/Services/OpenAccess/OpenAccessReferenceEnricherTest.php tests/Unit/Command/PurgeRedundantOpenAccessLinksCommandTest.php tests/Unit/Command/OpenAccessEnrichReferencesCommandTest.php` — 21 tests, 58 assertions, all green
- [x] `vendor/bin/phpunit tests/Unit/Services/ tests/Unit/Command/` — full suite still green (123 tests)
- [x] `vendor/bin/phpstan analyse` on changed files — no errors
- [x] `php bin/console app:openaccess:purge-redundant-links --dry-run` against dev DB — matches manual SQL audit (1433 duplicates)
- [ ] Run `app:openaccess:purge-redundant-links` (without `--dry-run`) against production once merged