### PR TITLE
feat: allow typing a reference's target position instead of dragging

### DIFF
--- a/assets/__tests__/extract.test.js
+++ b/assets/__tests__/extract.test.js
@@ -59,9 +59,11 @@ describe('extract.js', () => {
                 <button id="confirm-adding" type="button"></button>
                 <div id="doi-error-msg" class="d-none"></div>
 
-                <div id="sortref">
+                <div id="sortref" data-position-aria-template="Reference position, activate to move: {position} of {total}">
                     <div class="container-reference" data-idref="1">
-                        <span class="ref-position-badge">1</span>
+                        <div class="ref-position-wrapper">
+                            <button type="button" class="ref-position-badge" aria-label="Reference position, activate to move: 1 of 3">1</button>
+                        </div>
                         <div id="container-reference-informations-1">
                             <div id="textReference-1">Original Text</div>
                             <a id="linkDoiRef-1" href="https://doi.org/10.1000/old">10.1000/old</a>
@@ -88,13 +90,26 @@ describe('extract.js', () => {
                         </div>
                     </div>
                     <div class="container-reference" data-idref="2">
-                        <span class="ref-position-badge">2</span>
+                        <div class="ref-position-wrapper">
+                            <button type="button" class="ref-position-badge" aria-label="Reference position, activate to move: 2 of 3">2</button>
+                        </div>
                         <div id="textReference-2">Other Text</div>
                         <input id="reference-2" value='{}'>
                         <input id="accepted-2" value="1">
                         <input data-dirty-ref="2" value="0">
                     </div>
+                    <div class="container-reference" data-idref="3">
+                        <div class="ref-position-wrapper">
+                            <button type="button" class="ref-position-badge" aria-label="Reference position, activate to move: 3 of 3">3</button>
+                        </div>
+                        <div id="textReference-3">Third Text</div>
+                        <input id="reference-3" value='{}'>
+                        <input id="accepted-3" value="1">
+                        <input data-dirty-ref="3" value="0">
+                    </div>
                 </div>
+                <div id="reorder-live-region"></div>
+                <input id="document_orderRef" value="">
                 <input id="document_save" type="button">
                 <div id="loading-screen" class="d-none"></div>
                 <button id="extract-all" type="button" data-url-from-epi="test-url"></button>
@@ -684,5 +699,137 @@ describe('extract.js', () => {
         expect(cancelBtn).toHaveClass('d-none');
         expect(toggleAllBtn).toHaveClass('d-none');
         expect(deleteCheck.checked).toBe(false);
+    });
+
+    describe('editable reference position', () => {
+        const getBadge = (idRef) =>
+            document.querySelector(`.container-reference[data-idref="${idRef}"] .ref-position-badge`);
+
+        const orderOf = () =>
+            Array.from(document.querySelectorAll('#sortref .container-reference')).map((el) => el.dataset.idref);
+
+        test('does not initiate drag from within the position input', () => {
+            const { Sortable } = require('sortablejs/modular/sortable.core.esm');
+            const lastCall = Sortable.create.mock.calls.at(-1);
+            expect(lastCall[1].filter).toContain('ref-position-input');
+        });
+
+        test('clicking the badge reveals a number input scoped to the reference count', () => {
+            const badge = getBadge('2');
+            fireEvent.click(badge);
+
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            expect(input).not.toBeNull();
+            expect(input.type).toBe('number');
+            expect(input.min).toBe('1');
+            expect(input.max).toBe('3');
+            expect(input.value).toBe('2');
+            expect(badge).toHaveClass('d-none');
+        });
+
+        test('pressing Enter with a new position moves the reference and autosaves the new order', async () => {
+            const badge = getBadge('1');
+            fireEvent.click(badge);
+
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '3';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(orderOf()).toEqual(['2', '3', '1']);
+            expect(document.getElementById('document_orderRef').value).toBe('2;3;1');
+            expect(badge.parentElement.querySelector('input')).toBeNull();
+            expect(badge).not.toHaveClass('d-none');
+            expect(badge.textContent).toBe('3');
+
+            await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/autosave', expect.any(Object)));
+        });
+
+        test('renumbers badges and refreshes their aria-labels after a move', () => {
+            const badge = getBadge('3');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '1';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(getBadge('3').textContent).toBe('1');
+            expect(getBadge('3').getAttribute('aria-label')).toBe('Reference position, activate to move: 1 of 3');
+            expect(getBadge('1').textContent).toBe('2');
+            expect(getBadge('2').textContent).toBe('3');
+        });
+
+        test('announces the new position in the live region', () => {
+            window.translations = {
+                'Reference moved to position {position} of {total}.': 'Moved to {position} of {total}.',
+            };
+            const badge = getBadge('2');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '1';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(document.getElementById('reorder-live-region').textContent).toBe('Moved to 1 of 3.');
+        });
+
+        test('pressing Escape cancels the edit without saving', () => {
+            const badge = getBadge('2');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '1';
+            fireEvent.keyDown(input, { key: 'Escape' });
+
+            expect(orderOf()).toEqual(['1', '2', '3']);
+            expect(badge.parentElement.querySelector('input')).toBeNull();
+            expect(badge.textContent).toBe('2');
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        test('blurring the input commits the value like Enter', () => {
+            const badge = getBadge('1');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '2';
+            fireEvent.blur(input);
+
+            expect(orderOf()).toEqual(['2', '1', '3']);
+        });
+
+        test('clamps an out-of-range value to the last position', () => {
+            const badge = getBadge('1');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '999';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(orderOf()).toEqual(['2', '3', '1']);
+        });
+
+        test('clamps a value below 1 to the first position', () => {
+            const badge = getBadge('3');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '-5';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(orderOf()).toEqual(['3', '1', '2']);
+        });
+
+        test('does not autosave when the position is unchanged', () => {
+            const badge = getBadge('2');
+            fireEvent.click(badge);
+            const input = badge.parentElement.querySelector('input.ref-position-input');
+            input.value = '2';
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(orderOf()).toEqual(['1', '2', '3']);
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        test('clicking the badge again while editing does not spawn a second input', () => {
+            const badge = getBadge('1');
+            fireEvent.click(badge);
+            fireEvent.click(badge);
+
+            expect(badge.parentElement.querySelectorAll('input').length).toBe(1);
+        });
     });
 });

--- a/assets/js/extract.js
+++ b/assets/js/extract.js
@@ -53,6 +53,11 @@ const setContent = (element, content) => {
     element.value = content;
 };
 
+const announceLiveRegion = (message) => {
+    const liveRegion = document.getElementById('reorder-live-region');
+    if (liveRegion) liveRegion.textContent = message;
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOI Enrichment: DOMContentLoaded triggered');
     let sortEl = null;
@@ -62,7 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
             easing: 'cubic-bezier(0.11, 0, 0.5, 0)',
             animation: 150,
             ghostClass: 'highlighted',
-            filter: '.filtered',
+            filter: '.filtered, .ref-position-input',
             touchStartThreshold: 5,
             onStart() {
                 initialOrder = Array.from(document.querySelectorAll('.container-reference'))
@@ -81,11 +86,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     let hiddenRefNode = document.getElementById('document_orderRef');
                     if (hiddenRefNode) hiddenRefNode.value = strOrder;
                     autosave({ orderRef: strOrder });
+                    announceLiveRegion(
+                        window.translations?.['Reference order updated.'] ?? 'Reference order updated.',
+                    );
                 }
                 updateBadges();
             },
         });
         disabledSortWhenChangeRef(sortEl);
+        manageEditablePosition();
     }
 
     // Bootstrap modal initialisation
@@ -992,9 +1001,103 @@ function acceptRefModificationsDone(idRef) {
 }
 
 function updateBadges() {
-    document.querySelectorAll('#sortref .container-reference').forEach((el, index) => {
+    const container = document.getElementById('sortref');
+    if (!container) return;
+    const template =
+        container.dataset.positionAriaTemplate ?? 'Reference position, activate to move: {position} of {total}';
+    const refs = container.querySelectorAll('.container-reference');
+    const total = refs.length;
+    refs.forEach((el, index) => {
         const badge = el.querySelector('.ref-position-badge');
-        if (badge) badge.textContent = index + 1;
+        if (!badge) return;
+        const position = index + 1;
+        badge.textContent = position;
+        badge.setAttribute('aria-label', template.replace('{position}', position).replace('{total}', total));
+    });
+}
+
+// Lets a keyboard or mouse user retype a reference's position instead of dragging it,
+// which is impractical once the list grows past a few dozen items.
+function manageEditablePosition() {
+    const container = document.getElementById('sortref');
+    if (!container) return;
+
+    const commitMove = (badge, rawValue, currentPosition, total) => {
+        const parsed = parseInt(rawValue, 10);
+        const targetPosition = Number.isNaN(parsed) ? currentPosition : Math.min(Math.max(parsed, 1), total);
+        if (targetPosition === currentPosition) return;
+
+        const card = badge.closest('.container-reference');
+        const refs = Array.from(container.querySelectorAll('.container-reference'));
+        const currentIndex = refs.indexOf(card);
+        refs.splice(currentIndex, 1);
+        refs.splice(targetPosition - 1, 0, card);
+        refs.forEach((el) => container.appendChild(el));
+
+        const strOrder = refs.map((el) => el.dataset.idref).join(';');
+        const hiddenRefNode = document.getElementById('document_orderRef');
+        if (hiddenRefNode) hiddenRefNode.value = strOrder;
+        autosave({ orderRef: strOrder });
+        updateBadges();
+
+        const template =
+            window.translations?.['Reference moved to position {position} of {total}.'] ??
+            'Reference moved to position {position} of {total}.';
+        announceLiveRegion(template.replace('{position}', targetPosition).replace('{total}', total));
+    };
+
+    const enterEdit = (badge) => {
+        const wrapper = badge.parentElement;
+        if (wrapper.querySelector('input')) return;
+
+        const total = container.querySelectorAll('.container-reference').length;
+        const currentPosition = parseInt(badge.textContent, 10) || 1;
+        const originalLabel = badge.textContent;
+
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '1';
+        input.max = String(total);
+        input.value = String(currentPosition);
+        input.className = 'form-control form-control-sm ref-position-input';
+        const inputLabelTemplate =
+            window.translations?.['New position (1 to {total})'] ?? 'New position (1 to {total})';
+        input.setAttribute('aria-label', inputLabelTemplate.replace('{total}', total));
+
+        badge.classList.add('d-none');
+        wrapper.appendChild(input);
+        input.focus();
+        input.select();
+
+        const finish = (commit) => {
+            const value = input.value;
+            input.removeEventListener('keydown', onKeyDown);
+            input.removeEventListener('blur', onBlur);
+            input.remove();
+            badge.textContent = originalLabel;
+            badge.classList.remove('d-none');
+            if (commit) commitMove(badge, value, currentPosition, total);
+            badge.focus();
+        };
+
+        const onKeyDown = (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                finish(true);
+            } else if (event.key === 'Escape') {
+                event.preventDefault();
+                finish(false);
+            }
+        };
+        const onBlur = () => finish(true);
+
+        input.addEventListener('keydown', onKeyDown);
+        input.addEventListener('blur', onBlur);
+    };
+
+    container.addEventListener('click', (event) => {
+        const badge = event.target.closest('.ref-position-badge');
+        if (badge && !badge.parentElement.querySelector('input')) enterEdit(badge);
     });
 }
 

--- a/assets/js/extract.js
+++ b/assets/js/extract.js
@@ -58,6 +58,16 @@ const announceLiveRegion = (message) => {
     if (liveRegion) liveRegion.textContent = message;
 };
 
+// Looks up `key` in window.translations (falling back to the key itself, which
+// doubles as the English text) and fills in any {placeholder} params.
+const translate = (key, params = {}) => {
+    const template = window.translations?.[key] ?? key;
+    return Object.entries(params).reduce(
+        (text, [placeholder, value]) => text.replace(`{${placeholder}}`, value),
+        template,
+    );
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOI Enrichment: DOMContentLoaded triggered');
     let sortEl = null;
@@ -86,9 +96,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     let hiddenRefNode = document.getElementById('document_orderRef');
                     if (hiddenRefNode) hiddenRefNode.value = strOrder;
                     autosave({ orderRef: strOrder });
-                    announceLiveRegion(
-                        window.translations?.['Reference order updated.'] ?? 'Reference order updated.',
-                    );
+                    announceLiveRegion(translate('Reference order updated.'));
                 }
                 updateBadges();
             },
@@ -1040,10 +1048,9 @@ function manageEditablePosition() {
         autosave({ orderRef: strOrder });
         updateBadges();
 
-        const template =
-            window.translations?.['Reference moved to position {position} of {total}.'] ??
-            'Reference moved to position {position} of {total}.';
-        announceLiveRegion(template.replace('{position}', targetPosition).replace('{total}', total));
+        announceLiveRegion(
+            translate('Reference moved to position {position} of {total}.', { position: targetPosition, total }),
+        );
     };
 
     const enterEdit = (badge) => {
@@ -1060,9 +1067,7 @@ function manageEditablePosition() {
         input.max = String(total);
         input.value = String(currentPosition);
         input.className = 'form-control form-control-sm ref-position-input';
-        const inputLabelTemplate =
-            window.translations?.['New position (1 to {total})'] ?? 'New position (1 to {total})';
-        input.setAttribute('aria-label', inputLabelTemplate.replace('{total}', total));
+        input.setAttribute('aria-label', translate('New position (1 to {total})', { total }));
 
         badge.classList.add('d-none');
         wrapper.appendChild(input);

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -98,3 +98,20 @@
 // Delete mode: hide controls, show checkboxes via parent class toggle
 #sortref.delete-mode .ref-controls    { display: none !important; }
 #sortref.delete-mode .ref-delete-check { display: block !important; }
+
+// Editable reference position badge: keep the pill look on a real <button>
+// so it stays keyboard-operable without a visual regression.
+.ref-position-badge {
+    cursor: pointer;
+
+    &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: 2px;
+    }
+}
+
+.ref-position-input {
+    width: 3.5rem;
+    padding: 0.1rem 0.25rem;
+    text-align: center;
+}

--- a/templates/extract/index.html.twig
+++ b/templates/extract/index.html.twig
@@ -21,7 +21,10 @@
             'autofix-all-confirm-body': '{{ 'autofix-all-confirm-body'|trans }}',
             'autofix-complete': '{{ 'autofix-complete'|trans }}',
             'No references with DOI found': '{{ 'No references with DOI found'|trans }}',
-            'Invalid DOI, URL or SWHID format': '{{ 'Invalid DOI, URL or SWHID format'|trans }}'
+            'Invalid DOI, URL or SWHID format': '{{ 'Invalid DOI, URL or SWHID format'|trans }}',
+            'New position (1 to {total})': '{{ 'New position (1 to {total})'|trans }}',
+            'Reference moved to position {position} of {total}.': '{{ 'Reference moved to position {position} of {total}.'|trans }}',
+            'Reference order updated.': '{{ 'Reference order updated.'|trans }}'
         };
     </script>
     {{ encore_entry_script_tags('extract') }}
@@ -210,7 +213,8 @@
                 'SEMANTICS': 'fas fa-graduation-cap',
                 'BIBTEX':    'fas fa-file-import'
             } %}
-            <div id="sortref">
+            <div id="sortref" data-position-aria-template="{{ 'Reference position, activate to move: {position} of {total}'|trans }}">
+                {% set referencesCount = form.paperReferences|length %}
                 {% for paperReferences in form.paperReferences %}
                     {% set jsonDecodedRef = prettyReference(paperReferences.reference.vars.data) %}
                     {% set doiDecodedRef = '' %}
@@ -232,7 +236,11 @@
                     <div class="card mb-2 shadow-sm container-reference position-relative{% if isDeclined %} declinedRef filtered{% else %} acceptedRef{% endif %}{% if hasDetectors %} border-danger-important{% endif %}"
                          data-idref="{{ paperReferences.id.vars.value }}"
                          data-has-detectors="{% if hasDetectors %}1{% else %}0{% endif %}">
-                        <span class="badge rounded-pill bg-light text-dark position-absolute top-0 start-0 m-1 ref-position-badge" aria-label="{{ 'Citation number'|trans }}">{{ loop.index }}</span>
+                        <div class="position-absolute top-0 start-0 m-1 ref-position-wrapper">
+                            <button type="button"
+                                    class="badge rounded-pill bg-light text-dark border-0 ref-position-badge"
+                                    aria-label="{{ ('Reference position, activate to move: {position} of {total}'|trans)|replace({'{position}': loop.index, '{total}': referencesCount}) }}">{{ loop.index }}</button>
+                        </div>
                         <span class="badge source-color-{{ paperReferences.vars.data.source|lower }} position-absolute bottom-0 end-0 m-2">
                             <i class="{{ sourceIcons[paperReferences.vars.data.source] ?? 'fas fa-tag' }} me-1" aria-hidden="true"></i>{{ 'Source'|trans }}: {{ paperReferences.vars.data.source|trans }}
                         </span>
@@ -401,6 +409,7 @@
 
                 {% endfor %}
             </div>
+            <div id="reorder-live-region" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
 
             {% endif %}
 

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -97,6 +97,10 @@ Auto-fix all references with DOI: Auto-fix all references with DOI
 autofix-all-confirm-body: 'This will automatically correct {count} reference(s) that have a DOI. Do you want to continue?'
 autofix-complete: '{done} reference(s) auto-fixed'
 No references with DOI found: No references with a DOI were found
+'Reference position, activate to move: {position} of {total}': 'Reference position, activate to move: {position} of {total}'
+'New position (1 to {total})': 'New position (1 to {total})'
+'Reference moved to position {position} of {total}.': 'Reference moved to position {position} of {total}.'
+'Reference order updated.': Reference order updated.
 Saved: Saved
 Activate/Deactivate: Activate/Deactivate
 Close: Close

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -101,6 +101,10 @@ Auto-fix all references with DOI: Auto-corriger toutes les références avec DOI
 autofix-all-confirm-body: "Cette action va corriger automatiquement {count} référence(s) ayant un DOI. Voulez-vous continuer ?"
 autofix-complete: "{done} référence(s) corrigée(s) automatiquement"
 No references with DOI found: Aucune référence avec un DOI n'a été trouvée
+'Reference position, activate to move: {position} of {total}': "Position de la référence, activer pour la déplacer : {position} sur {total}"
+'New position (1 to {total})': "Nouvelle position (de 1 à {total})"
+'Reference moved to position {position} of {total}.': "Référence déplacée en position {position} sur {total}."
+'Reference order updated.': "Ordre des références mis à jour."
 Saved: Enregistré
 Activate/Deactivate: Activer/Désactiver
 Close: Fermer


### PR DESCRIPTION
## Summary
- Dragging references becomes impractical once a document has 30+ references. The position badge on each reference is now a keyboard-accessible button: activating it (click, or Enter/Space via keyboard) reveals a number input bounded to `[1, total]`. Typing a target position and pressing Enter (or blurring) moves the reference and reuses the existing autosave flow (`orderRef`). Escape cancels.
- Added a visually-hidden `aria-live="polite"` region that announces the new position after a move, wired into both this new flow and the existing drag-and-drop flow (which previously gave no feedback to screen reader users).
- Sortable.js's `filter` option now also excludes the new position input so it can't accidentally start a drag.

## Test plan
- [x] `npm test` — 80/80 Jest tests pass, including 12 new tests covering: opening the input, moving to start/middle/end, clamping out-of-range values, cancel via Escape, no-op when position unchanged, live region announcement, and no drag interference from the input.
- [x] `npx eslint` on changed JS files — no new errors (only pre-existing `no-console` warnings).
- [x] `php bin/console lint:twig` and `lint:yaml` — pass.
- [x] `npx sass` compile check on the SCSS — pass.
- [x] Manually rebuilt assets (`make npm-build`) and verified the new button/click handler ships in the built bundle.